### PR TITLE
Uses FORK instead of PSOCK R clusters on Linux/Mac

### DIFF
--- a/R/optimizeRetCorGroupParameters.R
+++ b/R/optimizeRetCorGroupParameters.R
@@ -328,7 +328,7 @@ function(params, xset, nSlaves=4) {
   parameters <- combineParams(parameters, typ_params$no_optimization)
   
   if(nSlaves > 1) {
-    cl <- parallel::makeCluster(nSlaves, type = "PSOCK")  #, outfile="log.txt")
+    cl <- parallel::makeCluster(nSlaves, type = getClusterType())  #, outfile="log.txt")
   #exporting all functions to cluster but only calcRGTV is needed
     ex <- Filter(function(x) is.function(get(x, .GlobalEnv)), ls(.GlobalEnv))
     parallel::clusterExport(cl, ex)

--- a/R/optimizeRetCorGroupParameters.R
+++ b/R/optimizeRetCorGroupParameters.R
@@ -329,11 +329,13 @@ function(params, xset, nSlaves=4) {
   
   if(nSlaves > 1) {
     cl_type<-getClusterType()
-    cl <- parallel::makeCluster(nSlaves, type = cl_type, outfile="log_ret.txt")
+    cl <- parallel::makeCluster(nSlaves, type = cl_type) #, outfile="log.txt")
   #exporting all functions to cluster but only calcRGTV is needed
     ex <- Filter(function(x) is.function(get(x, .GlobalEnv)), ls(.GlobalEnv))
     if(identical(cl_type,"PSOCK")) {
-      print("Exporting variables to cluster...")
+      message("Using PSOCK type cluster, this increases memory requirements.")
+      message("Reduce number of slaves if your have out of memory errors.")
+      message("Exporting variables to cluster...")
       parallel::clusterExport(cl, ex)
     }
     result <- parallel::parLapply(cl, tasks, optimizeRetGroupSlaveCluster, xset, 

--- a/R/optimizeRetCorGroupParameters.R
+++ b/R/optimizeRetCorGroupParameters.R
@@ -328,7 +328,7 @@ function(params, xset, nSlaves=4) {
   parameters <- combineParams(parameters, typ_params$no_optimization)
   
   if(nSlaves > 1) {
-    cl <- parallel::makeCluster(nSlaves, type = getClusterType())  #, outfile="log.txt")
+    cl <- parallel::makeCluster(nSlaves, type = getClusterType(), outfile="log_ret.txt")
   #exporting all functions to cluster but only calcRGTV is needed
     ex <- Filter(function(x) is.function(get(x, .GlobalEnv)), ls(.GlobalEnv))
     parallel::clusterExport(cl, ex)

--- a/R/optimizeRetCorGroupParameters.R
+++ b/R/optimizeRetCorGroupParameters.R
@@ -328,10 +328,12 @@ function(params, xset, nSlaves=4) {
   parameters <- combineParams(parameters, typ_params$no_optimization)
   
   if(nSlaves > 1) {
-    cl <- parallel::makeCluster(nSlaves, type = getClusterType(), outfile="log_ret.txt")
+    cl_type<-getClusterType()
+    cl <- parallel::makeCluster(nSlaves, type = cl_type, outfile="log_ret.txt")
   #exporting all functions to cluster but only calcRGTV is needed
     ex <- Filter(function(x) is.function(get(x, .GlobalEnv)), ls(.GlobalEnv))
-    if(identical(getClusterType(),"PSOCK")) {
+    if(identical(cl_type,"PSOCK")) {
+      print("Exporting variables to cluster...")
       parallel::clusterExport(cl, ex)
     }
     result <- parallel::parLapply(cl, tasks, optimizeRetGroupSlaveCluster, xset, 

--- a/R/optimizeRetCorGroupParameters.R
+++ b/R/optimizeRetCorGroupParameters.R
@@ -331,7 +331,9 @@ function(params, xset, nSlaves=4) {
     cl <- parallel::makeCluster(nSlaves, type = getClusterType(), outfile="log_ret.txt")
   #exporting all functions to cluster but only calcRGTV is needed
     ex <- Filter(function(x) is.function(get(x, .GlobalEnv)), ls(.GlobalEnv))
-    parallel::clusterExport(cl, ex)
+    if(identical(getClusterType(),"PSOCK")) {
+      parallel::clusterExport(cl, ex)
+    }
     result <- parallel::parLapply(cl, tasks, optimizeRetGroupSlaveCluster, xset, 
                                   parameters)
     parallel::stopCluster(cl)

--- a/R/optimizeXcmsSetParameters.R
+++ b/R/optimizeXcmsSetParameters.R
@@ -609,7 +609,9 @@ function(example_sample, params, scanrange, isotopeIdentification, nSlaves=4, ..
  
     #exporting all functions to cluster but only calcPPS and toMatrix are needed
     ex <- Filter(function(x) is.function(get(x, .GlobalEnv)), ls(.GlobalEnv))
-    parallel::clusterExport(cl, ex)
+    if(identical(getClusterType(),"PSOCK")) {
+      parallel::clusterExport(cl, ex)
+    }
     response <- parallel::parSapply(cl, tasks, optimizeSlaveCluster, xcms_design, 
                                     example_sample, scanrange, isotopeIdentification,
                                     ..., USE.NAMES=FALSE)

--- a/R/optimizeXcmsSetParameters.R
+++ b/R/optimizeXcmsSetParameters.R
@@ -604,7 +604,7 @@ function(example_sample, params, scanrange, isotopeIdentification, nSlaves=4, ..
   tasks <- 1:nrow(design)  
   
   if(nSlaves > 1) {
-    cl <- parallel::makeCluster(nSlaves, type = "PSOCK")
+    cl <- parallel::makeCluster(nSlaves, type = getClusterType())
     response <- matrix(0, nrow=length(design[[1]]), ncol=5)
  
     #exporting all functions to cluster but only calcPPS and toMatrix are needed

--- a/R/optimizeXcmsSetParameters.R
+++ b/R/optimizeXcmsSetParameters.R
@@ -611,7 +611,9 @@ function(example_sample, params, scanrange, isotopeIdentification, nSlaves=4, ..
     #exporting all functions to cluster but only calcPPS and toMatrix are needed
     ex <- Filter(function(x) is.function(get(x, .GlobalEnv)), ls(.GlobalEnv))
     if(identical(cl_type,"PSOCK")) {
-      print("Exporting variables to cluster...")
+      message("Using PSOCK type cluster, this increases memory requirements.")
+      message("Reduce number of slaves if your have out of memory errors.")
+      message("Exporting variables to cluster...")
       parallel::clusterExport(cl, ex)
     }
     response <- parallel::parSapply(cl, tasks, optimizeSlaveCluster, xcms_design, 

--- a/R/optimizeXcmsSetParameters.R
+++ b/R/optimizeXcmsSetParameters.R
@@ -604,12 +604,14 @@ function(example_sample, params, scanrange, isotopeIdentification, nSlaves=4, ..
   tasks <- 1:nrow(design)  
   
   if(nSlaves > 1) {
-    cl <- parallel::makeCluster(nSlaves, type = getClusterType())
+    cl_type<-getClusterType()
+    cl <- parallel::makeCluster(nSlaves, type = cl_type)
     response <- matrix(0, nrow=length(design[[1]]), ncol=5)
  
     #exporting all functions to cluster but only calcPPS and toMatrix are needed
     ex <- Filter(function(x) is.function(get(x, .GlobalEnv)), ls(.GlobalEnv))
-    if(identical(getClusterType(),"PSOCK")) {
+    if(identical(cl_type,"PSOCK")) {
+      print("Exporting variables to cluster...")
       parallel::clusterExport(cl, ex)
     }
     response <- parallel::parSapply(cl, tasks, optimizeSlaveCluster, xcms_design, 

--- a/R/utils.R
+++ b/R/utils.R
@@ -446,3 +446,12 @@ writeParamsTable <-
 function(peakPickingSettings, retCorGroupSettings, file, ...) {
   write.table(combineParams(peakPickingSettings, retCorGroupSettings), file, ...)
 }
+
+
+getClusterType <-
+function() {
+  if( .Platform$OS.type=="unix" ) {
+    return("FORK")
+  }
+  return("PSOCK")
+}


### PR DESCRIPTION
On unix platforms, R can use a different clustering mode called FORK, which is supposed to be less memory hungry than PSOCK. Changes on this pull request allow this mode to be used automatically by IPO if available on the platform, and warn the user if PSOCK is being used.